### PR TITLE
Add ability to generate a maze using a random seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+* Ability to use a seeded random number generator to generate a maze
 
 ## [1.0.2] - 2020-02-24
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Run `npm i maze-generation`
 
 ### Usage
 
-Add the following to your code (where width and height should be replaced by ints corresponding to how wide and tall you want your maze):
+Add the following to your code (where width and height should be replaced by ints corresponding to how wide and tall you want your maze; and seed should be replaced by an int):
 
 ```
 const mazegeneration = require('maze-generation');
 // Generate a maze
-const generatedMaze = mazegeneration(width,height);
+const generatedMaze = mazegeneration(width,height,seed);
 ```
 
 To get the string representation of the generated maze write:
@@ -31,16 +31,17 @@ console.log(stringRepresenation);
 
 Example output:
 ```
-|- -|- - -|- = = = -|
-| |_ _| | |_ _  | | |
-|_|    _|_ _ _ _| | |
-|  _|_|  _  |  _ _| |
-|_ _  |_|  _| |  _ _|
-|   | |  _|   |_  | |
-| | |_ _|_  |_ _| | |
-| |   |     |   | | |
-| | |_| | |_| | | | |
-|_|_ _ _|_ _ _|_ _ _|
+|- = = =|- = - -|- -|
+|  _ _ _ _|  _| | | |
+|_  |  _  |_  |_ _| |
+|  _| | |_  | |_ _  |
+|_  | |  _ _|_ _  | |
+| | | | |  _  |  _| |
+| | | | |_  |_| |_ _|
+| |_ _|  _ _|  _|  _|
+|  _ _| |  _ _|  _| |
+|_ _ _ _|_ _ _ _ _ _|
+
 ```
 
 To get the JSON representation of the generated maze write:
@@ -86,4 +87,3 @@ We use [SemVer](http://semver.org/) for versioning.
 ## Acknowledgments
 
 * README format based off of [PurpleBooth's README template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)
-

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const DepthFirst = require('./src/GenerationAlgorithms/DepthFirst');
 
-module.exports = (width, height) => {
-  const df = new DepthFirst(width, height);
+module.exports = (width, height, seed) => {
+  const df = new DepthFirst(width, height, seed);
   return df.generateMaze();
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "mazegen",
-  "version": "1.0.0",
+  "name": "maze-generation",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4266,6 +4266,11 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "prando": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/prando/-/prando-5.1.2.tgz",
+      "integrity": "sha512-PaJxPMw8UugKUeUq27oZ8dqW2CgysXf2MjmlyCcRq+Es8Bcxgac7+nO6/tRGKmLOnUG1GPbAATNAZmzwD1hbIA=="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,26 @@
   "name": "maze-generation",
   "version": "1.0.2",
   "description": "A package to generate mazes using the depth first / recursive backtracker algorithm.",
-  "homepage":"https://github.com/JRIngram/maze-gen",
-  "bugs":"https://github.com/JRIngram/maze-gen/issues",
+  "homepage": "https://github.com/JRIngram/maze-gen",
+  "bugs": "https://github.com/JRIngram/maze-gen/issues",
   "repository": {
-    "type":"git",
+    "type": "git",
     "url": "https://github.com/JRIngram/maze-gen.git"
   },
-  "keywords":["maze", "generator", "maze-gen", "maze-gen", "gen", "depth-first", "procedural", "recursive", "backtracker", "depth", "first", "depth-first"],
+  "keywords": [
+    "maze",
+    "generator",
+    "maze-gen",
+    "maze-gen",
+    "gen",
+    "depth-first",
+    "procedural",
+    "recursive",
+    "backtracker",
+    "depth",
+    "first",
+    "depth-first"
+  ],
   "main": "index.js",
   "scripts": {
     "test": "jest",
@@ -17,8 +30,8 @@
     "linter:fix": "semistandard --fix"
   },
   "author": {
-     "name": "Jamie Ingram",
-     "url": "https://github.com/JRIngram"
+    "name": "Jamie Ingram",
+    "url": "https://github.com/JRIngram"
   },
   "license": "MIT",
   "devDependencies": {
@@ -29,5 +42,8 @@
     "env": [
       "jest"
     ]
+  },
+  "dependencies": {
+    "prando": "^5.1.2"
   }
 }

--- a/src/GenerationAlgorithms/DepthFirst.js
+++ b/src/GenerationAlgorithms/DepthFirst.js
@@ -1,9 +1,21 @@
+const Prando = require('prando');
 const Maze = require('../Maze');
 
 class DepthFirst {
-  constructor (width, height) {
+  constructor (width, height, seed = (Math.floor(Math.random() * 10000))) {
+    this.rng = new Prando(seed);
     this.maze = new Maze(width, height);
+    this.width = width;
+    this.height = height;
     this.cellStack = [];
+  }
+
+  /**
+    * Picks a random cell from the maze and returns it
+    * @returns {Cell} A random cell from the maze
+    */
+  getRandomCell () {
+    return { randomHeight: this.rng.nextInt(0, this.height - 1), randomWidth: this.rng.nextInt(0, this.width - 1) };
   }
 
   /**
@@ -19,7 +31,7 @@ class DepthFirst {
    */
   generateMaze () {
     // Set currentCell = random cell
-    const randomCell = this.maze.getRandomCell();
+    const randomCell = this.getRandomCell();
     // Select random cell
     let currentCell = { x: randomCell.randomWidth, y: randomCell.randomHeight };
     this.generatePath(currentCell);
@@ -50,7 +62,7 @@ class DepthFirst {
       // Push current cell to stack to allow for backtracking
       this.cellStack.push(currentCell);
       // Randomly select a valid direction and remove the wall
-      const nextDirection = validDirections[Math.floor(Math.random() * validDirections.length)];
+      const nextDirection = validDirections[this.rng.nextInt(0, validDirections.length - 1)];
       this.maze.removeWall(currentCell.y, currentCell.x, nextDirection);
 
       // Move to the cell in the direction of the removed wall

--- a/src/GenerationAlgorithms/DepthFirst.js
+++ b/src/GenerationAlgorithms/DepthFirst.js
@@ -12,7 +12,7 @@ class DepthFirst {
 
   /**
     * Picks a random cell from the maze and returns it
-    * @returns {Cell} A random cell from the maze
+    * @returns {{int, int}} Coordinates of a random cell within the maze
     */
   getRandomCell () {
     return { randomHeight: this.rng.nextInt(0, this.height - 1), randomWidth: this.rng.nextInt(0, this.width - 1) };

--- a/src/Maze.js
+++ b/src/Maze.js
@@ -84,16 +84,6 @@ class Maze {
   }
 
   /**
-     * Picks a random cell from the maze and returns it
-     * @returns {Cell} A random cell from the maze
-     */
-  getRandomCell () {
-    const mazeHeight = this.cells.length;
-    const mazeWidth = this.cells[0].length;
-    return { randomHeight: Math.floor(Math.random() * mazeHeight), randomWidth: Math.floor(Math.random() * mazeWidth) };
-  }
-
-  /**
      * Gets the indicies of neighbouring cells
      * @param {*} row The row index of the cell
      * @param {*} column The column index of the cell

--- a/src/test/depthFirst.test.js
+++ b/src/test/depthFirst.test.js
@@ -1,0 +1,33 @@
+const getType = require('jest-get-type');
+const DepthFirst = require('../GenerationAlgorithms/DepthFirst');
+/* eslint-env jest */
+
+describe('DepthFirst alogorithm', () => {
+  it('Returns an object', () => {
+    const df = new DepthFirst(3, 3);
+    expect(getType(df.generateMaze())).toBe('object');
+  });
+
+  it('Returns the same maze structure when given the same seed', () => {
+    const df1 = new DepthFirst(3, 3, 123);
+    const df2 = new DepthFirst(3, 3, 123);
+    expect(df2.generateMaze()).toEqual(df1.generateMaze());
+  });
+
+  it('Returns the a different maze structure when given a different seed', () => {
+    const df1 = new DepthFirst(3, 3, 123);
+    const df2 = new DepthFirst(3, 3, 321);
+    expect(df2.generateMaze()).not.toEqual(df1.generateMaze());
+  });
+});
+
+describe('Random cell', () => {
+  test('Can get a random cell', () => {
+    const df = new DepthFirst(3, 3);
+    const actual = df.getRandomCell();
+    expect(actual.randomHeight).toBeLessThan(4);
+    expect(actual.randomHeight).toBeGreaterThanOrEqual(0);
+    expect(actual.randomWidth).toBeLessThan(3);
+    expect(actual.randomWidth).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/test/maze.test.js
+++ b/src/test/maze.test.js
@@ -109,15 +109,6 @@ test('Can create a visible path through a maze', () => {
   expect(maze.toString()).toBe('|= -| |\n|_| | |\n|_|_ _|');
 });
 
-test('Can get a random cell', () => {
-  const maze = new Maze(3, 4);
-  const actual = maze.getRandomCell();
-  expect(actual.randomHeight).toBeLessThan(4);
-  expect(actual.randomHeight).toBeGreaterThanOrEqual(0);
-  expect(actual.randomWidth).toBeLessThan(3);
-  expect(actual.randomWidth).toBeGreaterThanOrEqual(0);
-});
-
 // Cell neighbours
 test('Can get all neighbours indicies if in centre', () => {
   const maze = new Maze(3, 3);


### PR DESCRIPTION
# Pull Request (PR) - Seeded Maze Gen
## Description of Change

Add the ability to generate mazes using seeds for random number generators.

## Link To Issue 

<!--
    Provide a link to the Issue on GitHub.
    If there is not an issue open write a reason why there is no issue open.
    Ideally PRs should all have issues so that appropriate discussions can be had prior to development / a PR being openned.
-->
N/A

## How to test this change
Create three mazes: two with the same seed one with another. 
Print the string of all mazes and ensure those with the same seed are the same and the other is different.
<!-- 
    Write a description of how this change can be tested by the reviewer of your PR
-->

## Checklists
### Checklist for developer of feature
- [x] I have performed a code review on my own code
- [x] I have written unit tests to test my code
- [x] I have linked to the appropriate issue on GitHub
- [x] I have written an appropriate description for this PR.
- [x] I have written how to test this PR.
- [x] I have updated the documentation (JSDoc / README etc.) where appropriate
- [x] I have commented my code.
- [x] I have updated the changelog.

### Checklist for reviewers
- [x] I have reviewed the new code
- [x] I have checked that new unit tests have been written
- [x] I have ran the unit tests and they pass.
- [x] I have followed the given steps to test the PR


